### PR TITLE
Fix meta tag quoting

### DIFF
--- a/main.html
+++ b/main.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv=“X-UA-Compatible” content=“ie=edge”>
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Document</title>
     <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
     <link rel="stylesheet" href="main.css">


### PR DESCRIPTION
## Summary
- use standard quotes in main.html for X-UA-Compatible meta tag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4c74ea3883318fb5629126c75dbe