### PR TITLE
Make page responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,11 +16,13 @@
 <body>
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <h1>Visitor Stats</h1>
-  <p>Current time: <span id="time">--:--:--</span></p>
-  <p>Your IP: <span id="ip">Loading...</span></p>
-  <p>Your Location: <span id="location">Loading...</span></p>
-  <p>Active users: <span id="users">1</span></p>
+  <div class="container">
+    <h1>Visitor Stats</h1>
+    <p>Current time: <span id="time">--:--:--</span></p>
+    <p>Your IP: <span id="ip">Loading...</span></p>
+    <p>Your Location: <span id="location">Loading...</span></p>
+    <p>Page views: <span id="pageViews">Loading...</span></p>
+  </div>
   <script src="stats.js"></script>
 </body>
 </html>

--- a/main.css
+++ b/main.css
@@ -120,3 +120,31 @@ body{
     text-decoration: underline;
     transform: scale(1.02);
 }
+
+/* Styles for visitor stats page */
+.container {
+    background: rgba(255, 255, 255, 0.85);
+    color: #333;
+    padding: 20px;
+    border-radius: 10px;
+    max-width: 600px;
+    width: 100%;
+}
+
+.container h1,
+.container p {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+@media (max-width: 480px) {
+    .main {
+        width: 100%;
+        padding: 20px;
+    }
+
+    .container {
+        padding: 15px;
+        width: 100%;
+    }
+}

--- a/stats.js
+++ b/stats.js
@@ -17,3 +17,12 @@ fetch('https://ipapi.co/json/')
     document.getElementById('ip').textContent = 'Unavailable';
     document.getElementById('location').textContent = 'Unavailable';
   });
+
+fetch('https://api.countapi.xyz/hit/visitor-stats-demo/github')
+  .then(r => r.json())
+  .then(data => {
+    document.getElementById('pageViews').textContent = data.value;
+  })
+  .catch(() => {
+    document.getElementById('pageViews').textContent = 'Unavailable';
+  });


### PR DESCRIPTION
## Summary
- wrap stats in a responsive container
- style container and add mobile layout tweaks
- show page view count using CountAPI

## Testing
- `npm test` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_683f4dbf464483319c64ec6c6361a91e