### PR TITLE
Add random animal sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
     <p>Your Location: <span id="location">Loading...</span></p>
     <p>Page views: <span id="pageViews">Loading...</span></p>
     <p>Live sessions: <span id="liveSessions">Loading...</span></p>
+    <p>Your animal: <span id="yourAnimal">Loading...</span></p>
+    <p>Other animals online: <span id="otherAnimals">Loading...</span></p>
   </div>
   <script src="stats.js"></script>
 </body>

--- a/stats.js
+++ b/stats.js
@@ -23,6 +23,33 @@ Promise.all([
 
 const countNamespace = 'visitor-stats-demo';
 
+const animals = ['Fox', 'Cat', 'Dog', 'Llama', 'Tiger', 'Koala', 'Panda', 'Hedgehog', 'Eagle', 'Otter'];
+let animal = sessionStorage.getItem('animal');
+if (!animal) {
+  animal = animals[Math.floor(Math.random() * animals.length)];
+  sessionStorage.setItem('animal', animal);
+}
+document.getElementById('yourAnimal').textContent = animal;
+
+fetch(`https://api.countapi.xyz/update/${countNamespace}/animal-${animal}/?amount=1`)
+  .then(() => Promise.all(
+    animals.map(a =>
+      fetch(`https://api.countapi.xyz/get/${countNamespace}/animal-${a}`)
+        .then(r => r.json())
+        .then(d => ({ name: a, count: d.value }))
+        .catch(() => ({ name: a, count: 0 }))
+    )
+  ))
+  .then(results => {
+    const others = results
+      .filter(r => r.count > 0 && r.name !== animal)
+      .map(r => r.name);
+    document.getElementById('otherAnimals').textContent = others.join(', ') || 'None';
+  })
+  .catch(() => {
+    document.getElementById('otherAnimals').textContent = 'Unavailable';
+  });
+
 // Update total page views
 fetch(`https://api.countapi.xyz/hit/${countNamespace}/pageviews`)
   .then(r => r.json())
@@ -46,4 +73,5 @@ fetch(`https://api.countapi.xyz/update/${countNamespace}/sessions/?amount=1`)
 
 window.addEventListener('beforeunload', () => {
   navigator.sendBeacon(`https://api.countapi.xyz/update/${countNamespace}/sessions/?amount=-1`);
+  navigator.sendBeacon(`https://api.countapi.xyz/update/${countNamespace}/animal-${animal}/?amount=-1`);
 });


### PR DESCRIPTION
## Summary
- assign random animal for each page session
- track animals via CountAPI and show which ones are online
- display the user's animal and the list of other animals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5154edc48331a0271ce3cb40e285